### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "javascript"
+run = "node"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 VueChess
 ========
-
+[![Run on Repl.it](https://repl.it/badge/github/UzayAnil/vue-chess)](https://repl.it/github/UzayAnil/vue-chess)
  - Users can create private or public games against other  real-time
    player or against the computer by choosing color, time and type of
    starting, if public other users can view.


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).